### PR TITLE
ユーザーアイコン機能の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'jbuilder', '~> 2.7'
 # gem 'bcrypt', '~> 3.1.7'
 
 # Use Active Storage variant
-# gem 'image_processing', '~> 1.2'
+gem 'image_processing', '~> 1.2'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -68,5 +68,3 @@ gem 'kaminari'
 
 gem 'omniauth'
 gem 'omniauth-github'
-
-gem 'mini_magick'

--- a/Gemfile
+++ b/Gemfile
@@ -68,3 +68,5 @@ gem 'kaminari'
 
 gem 'omniauth'
 gem 'omniauth-github'
+
+gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -317,6 +317,7 @@ DEPENDENCIES
   dotenv-rails
   faker
   i18n_generators
+  image_processing (~> 1.2)
   jbuilder (~> 2.7)
   kaminari
   letter_opener_web

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -322,7 +322,6 @@ DEPENDENCIES
   kaminari
   letter_opener_web
   listen (~> 3.2)
-  mini_magick
   omniauth
   omniauth-github
   puma (~> 4.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -321,6 +321,7 @@ DEPENDENCIES
   kaminari
   letter_opener_web
   listen (~> 3.2)
+  mini_magick
   omniauth
   omniauth-github
   puma (~> 4.1)

--- a/app/assets/stylesheets/user.scss
+++ b/app/assets/stylesheets/user.scss
@@ -1,0 +1,4 @@
+.user-icon.large {
+  max-height: 600px;
+  max-width: 600px;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    keys = %i[name postal_code address self_introduction]
+    keys = %i[name postal_code address self_introduction icon]
     devise_parameter_sanitizer.permit(:sign_up, keys: keys)
     devise_parameter_sanitizer.permit(:account_update, keys: keys)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  has_one_attached :icon
+
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: %i[github]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,10 +9,6 @@ class User < ApplicationRecord
 
   validates :uid, uniqueness: { scope: :provider }, if: -> { uid.present? }
 
-  def small_icon
-    icon.variant(resize: '50x50').processed
-  end
-
   def self.from_omniauth(auth)
     find_or_create_by(provider: auth.provider, uid: auth.uid) do |user|
       user.name = auth.info.name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,10 @@ class User < ApplicationRecord
 
   validates :uid, uniqueness: { scope: :provider }, if: -> { uid.present? }
 
+  def small_icon
+    icon.variant(resize: '50x50').processed
+  end
+
   def self.from_omniauth(auth)
     find_or_create_by(provider: auth.provider, uid: auth.uid) do |user|
       user.name = auth.info.name

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -3,6 +3,15 @@
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
+
+  <div class="field">
+    <%= f.label :icon %><br />
+    <% if @user.icon.attached? %>
+      <%= image_tag @user.icon %>
+    <% end %>
+    <%= f.file_field :icon %>
+  </div>
+
   <div class="field">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -7,7 +7,7 @@
   <div class="field">
     <%= f.label :icon %><br />
     <% if @user.icon.attached? %>
-      <%= image_tag @user.icon %>
+      <%= image_tag @user.icon, class: 'user-icon large' %>
     <% end %>
     <%= f.file_field :icon %>
   </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -17,7 +17,7 @@
       <tr>
         <td>
           <% if user.icon.attached? %>
-            <%= image_tag icon.variant(resize: '50x50').processed %>
+            <%= image_tag user.icon.variant(resize: '50x50') %>
           <% end %>
         </td>
         <td><%= user.email %></td>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -3,6 +3,7 @@
 <table>
   <thead>
     <tr>
+      <th></th>
       <th><%= User.human_attribute_name(:email) %></th>
       <th><%= User.human_attribute_name(:name) %></th>
       <th><%= User.human_attribute_name(:postal_code) %></th>
@@ -14,6 +15,11 @@
   <tbody>
     <% @users.each do |user| %>
       <tr>
+        <td>
+          <% if user.icon.attached? %>
+            <%= image_tag user.small_icon %>
+          <% end %>
+        </td>
         <td><%= user.email %></td>
         <td><%= user.name %></td>
         <td><%= user.postal_code %></td>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -17,7 +17,7 @@
       <tr>
         <td>
           <% if user.icon.attached? %>
-            <%= image_tag user.small_icon %>
+            <%= image_tag icon.variant(resize: '50x50').processed %>
           <% end %>
         </td>
         <td><%= user.email %></td>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,6 +2,10 @@
 
 <h1><%= t('views.common.title_show', name: User.model_name.human) %></h1>
 
+<% if @user.icon.attached? %>
+  <%= image_tag @user.icon %>
+<% end %>
+
 <p>
   <strong><%= User.human_attribute_name(:email) %>:</strong>
   <%= @user.email %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,7 +3,7 @@
 <h1><%= t('views.common.title_show', name: User.model_name.human) %></h1>
 
 <% if @user.icon.attached? %>
-  <%= image_tag @user.icon %>
+  <%= image_tag @user.icon, class: 'user-icon large' %>
 <% end %>
 
 <p>

--- a/db/migrate/20201203083155_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20201203083155_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [:key], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index %i[record_type record_id name blob_id], name: 'index_active_storage_attachments_uniqueness', unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_22_065204) do
+ActiveRecord::Schema.define(version: 2020_12_03_083155) do
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
 
   create_table "books", force: :cascade do |t|
     t.string "title"
@@ -40,4 +61,5 @@ ActiveRecord::Schema.define(version: 2020_11_22_065204) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
ユーザー編集画面とユーザーページに大きめのアイコンを表示。
ユーザー一覧画面にはサイズを小さく変換したアイコンを表示。
(一覧で大きな画像を大量に読み込むと時間がかかって良くなさそう)